### PR TITLE
added the APIs for send and verify OTP

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/cors": "^2.8.17",
         "@types/nodemailer": "^6.4.17",
         "bcrypt": "^5.1.1",
         "body-parser": "^2.2.0",
@@ -1338,6 +1339,15 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/express": {
       "version": "5.0.1",

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/nodemailer": "^6.4.17",
         "bcrypt": "^5.1.1",
         "body-parser": "^2.2.0",
         "cookie-parser": "^1.4.7",
@@ -19,6 +20,7 @@
         "mongoose": "^8.13.2",
         "morgan": "^1.10.0",
         "nanoid": "^3.3.6",
+        "nodemailer": "^6.10.1",
         "nodemon": "^3.1.9",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
@@ -1460,9 +1462,17 @@
       "version": "22.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
       "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -4995,6 +5005,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.9",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
@@ -6352,7 +6371,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@types/nodemailer": "^6.4.17",
     "bcrypt": "^5.1.1",
     "body-parser": "^2.2.0",
     "cookie-parser": "^1.4.7",
@@ -22,6 +23,7 @@
     "mongoose": "^8.13.2",
     "morgan": "^1.10.0",
     "nanoid": "^3.3.6",
+    "nodemailer": "^6.10.1",
     "nodemon": "^3.1.9",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@types/cors": "^2.8.17",
     "@types/nodemailer": "^6.4.17",
     "bcrypt": "^5.1.1",
     "body-parser": "^2.2.0",

--- a/Backend/src/controllers/otpController.ts
+++ b/Backend/src/controllers/otpController.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express';
+import Otp from '../models/OTP/otpModel';
+import { transporter } from '../lib/mailer';
+
+export const generateOTP = (): string => {
+    return Math.floor(100000 + Math.random() * 900000).toString();
+};
+export const sendOtp = async (req: Request, res: Response): Promise<void> => {
+  const { email } = req.body;
+  if (!email) 
+    {
+        res.status(400).json({ error: 'Email is required' });
+        return;
+    }
+
+  const otp = generateOTP();
+  await Otp.create({ email, otp });
+
+  try {
+    await transporter.sendMail({
+      from: process.env.EMAIL,
+      to: email,
+      subject: 'Your OTP Code',
+      text: `Your OTP is: ${otp}`,
+    });
+    res.status(200).json({ message: 'OTP sent successfully' });
+    return;
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error'});
+    return;
+  }
+};
+export const verifyOtp = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { email, otp } = req.body;
+  
+    const record = await Otp.findOne({ email, otp });
+    if (!record){
+        res.status(400).json({ error: 'Invalid or expired OTP' });
+        return;
+    }
+    await Otp.deleteMany({ email });
+    res.status(200).json({ message: 'OTP verified successfully' });
+    return;
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error'});
+    return;
+  }
+};

--- a/Backend/src/index.ts
+++ b/Backend/src/index.ts
@@ -8,10 +8,14 @@ import cookieParser from "cookie-parser";
 import { setupSwagger } from "./swagger";
 import morgan = require("morgan");
 import assets from "./routes/assetsRouter";
+import cors from "cors";
 
 dotenv.config();
-const cors = require("cors");
-
+const corsOptions = {
+  origin: process.env.CORS_ORIGIN, // http://localhost:3000 for development and http://easyassets.vercel.app for production
+  methods: ["GET", "POST", "PUT", "DELETE"],
+  credentials: true,
+};
 const app = express();
 const port = process.env.PORT || 5000;
 app.use(
@@ -25,6 +29,7 @@ app.use(
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
+app.use(cors(corsOptions)); // Enable CORS with the specified options
 
 //For API Docs using Swagger UI
 setupSwagger(app);

--- a/Backend/src/index.ts
+++ b/Backend/src/index.ts
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import express, { Request, Response } from "express";
 import { connectDB } from "./lib/connectDB";
 import authRoutes from "./routes/authRouter";
+import otpRoutes from "./routes/otpRouter";
 import categoryRoutes from "./routes/categoryRouter";
 import cookieParser from "cookie-parser";
 import { setupSwagger } from "./swagger";
@@ -29,6 +30,7 @@ app.use(cookieParser());
 setupSwagger(app);
 
 app.use("/api/auth", authRoutes);
+app.use("/api/otp", otpRoutes);
 app.use("/api/categories", categoryRoutes);
 app.use("/api/assets", assets);
 

--- a/Backend/src/lib/mailer.ts
+++ b/Backend/src/lib/mailer.ts
@@ -1,0 +1,19 @@
+import nodemailer, { Transporter } from 'nodemailer';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const email = process.env.EMAIL;
+const emailPassword = process.env.EMAIL_PASSWORD;
+
+if (!email || !emailPassword) {
+  throw new Error('EMAIL or EMAIL_PASSWORD is not defined in environment variables');
+}
+
+export const transporter: Transporter = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: email,
+    pass: emailPassword,
+  },
+});

--- a/Backend/src/models/OTP/otpModel.ts
+++ b/Backend/src/models/OTP/otpModel.ts
@@ -1,0 +1,17 @@
+import mongoose, { Document, Model, Schema } from 'mongoose';
+
+interface IOtp extends Document {
+  email: string;
+  otp: string;
+  createdAt: Date;
+}
+
+const otpSchema: Schema<IOtp> = new mongoose.Schema({
+  email: { type: String, required: true },
+  otp: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now, expires: 300 },
+});
+
+const OtpModel: Model<IOtp> = mongoose.model<IOtp>('Otp', otpSchema);
+
+export default OtpModel;

--- a/Backend/src/routes/otpRouter.ts
+++ b/Backend/src/routes/otpRouter.ts
@@ -1,0 +1,67 @@
+import express from 'express';
+import { sendOtp, verifyOtp } from '../controllers/otpController';
+
+const router = express.Router();
+
+/**
+* @swagger
+* /api/otp/send-otp:
+*   post:
+*     summary: Sends an OTP to given email
+*     tags:
+*       - OTP
+*     responses:
+*       '200':
+*         description: OTP sent successfully
+*       '400':
+*         description: Email is required
+*       '500':
+*         description: Internal Server Error
+*     requestBody:
+*       required: true
+*       content:
+*         application/json:
+*           schema:
+*             type: object
+*             properties:
+*               email:
+*                 type: string
+*             required:
+*               - email
+* 
+*/
+router.post('/send-otp', sendOtp);
+
+/**
+* @swagger
+* /api/otp/verify-otp:
+*   post:
+*     summary: Validates the OTP
+*     tags:
+*       - OTP
+*     responses:
+*       '200':
+*         description: OTP verified successfully
+*       '400':
+*         description: Invalid or expired OTP
+*       '500':
+*         description: Internal Server Error
+*     requestBody:
+*       required: true
+*       content:
+*         application/json:
+*           schema:
+*             type: object
+*             properties:
+*               email:
+*                 type: string
+*               otp:
+*                 type: string
+*             required:
+*               - email
+*               - otp
+* 
+*/
+router.post('/verify-otp', verifyOtp);
+
+export default router;

--- a/Frontend/.env
+++ b/Frontend/.env
@@ -1,0 +1,1 @@
+VITE_AUTH_URL=http://localhost:5000

--- a/Frontend/.gitignore
+++ b/Frontend/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/Frontend/src/routes/authRoute.tsx
+++ b/Frontend/src/routes/authRoute.tsx
@@ -2,7 +2,7 @@ import axios from "axios";
 import { LoginResponse } from "../types/auth";
 import { SignupData } from "../types/auth";
 
-const AUTH_URL = "http://localhost:5000"; // Adjust to the route of the backend
+const AUTH_URL = import.meta.env.VITE_AUTH_URL; // http://localhost:5000 for local development and production URL for deployment
 
 // For Login Route
 export const login = async (


### PR DESCRIPTION
# 🔐 OTP Feature Documentation

## ✅ Features Implemented

### `POST /send-otp`
- Generates a **6-digit numeric OTP**.
- Sends the OTP to the specified email using **Nodemailer**.
- Stores the OTP in MongoDB with a **5-minute expiration**.

### `POST /verify-otp`
- Verifies the OTP associated with the provided email.
- Deletes the OTP from the database upon successful verification.

---

## 📁 File Changes

### `controllers/otpController.ts`
- Implements:
  - `sendOtp` handler
  - `verifyOtp` handler
  - `generateOTP` handler

### `models/Otp.ts`
- Defines Mongoose schema for OTP.
- Uses MongoDB's **TTL (Time-To-Live)** index to auto-expire OTPs after 5 minutes.

### `routes/otpRoutes.ts`
- Adds routes:
  - `POST /send-otp`
  - `POST /verify-otp`

### `config/mailer.ts`
- Configures **Nodemailer** using environment variables.
- Supports sending OTP emails via Gmail.

---

## ⚙️ Required Environment Variables

Ensure the following variables are defined in your `.env` file:

```env
EMAIL=your-email@gmail.com
EMAIL_PASSWORD=your-gmail-app-password